### PR TITLE
fixed dependency installation that was removed

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -2,6 +2,12 @@ const fs = require('fs');
 const execSync = require('child_process').execSync;
 
 module.exports = (api, options) => {
+  api.extendPackage({
+    devDependencies: {
+      'jest-serializer-vue-tjw': '^3.14.0'
+    }
+  })
+
   if (options.preset !== 'default') {
     const {
       verbose,


### PR DESCRIPTION
I made a mistake on the last PR and accidently removed some necessary code to add `jest-serializer-vue-tjw` as a dependency. This PR adds that code back into the project.